### PR TITLE
Example for target in sub-dir without namespacing.

### DIFF
--- a/README
+++ b/README
@@ -35,7 +35,8 @@ working directory to identify targets. Any directory that contains .go
 files or .c files will be identified as a target. Each target's name is then 
 determined by first looking at its relative path, but can be overridden by 
 either a target.gb file containing a new name, or a //target:<name> comment 
-in one of the source files, before the package statement. This renaming of 
+in one of the source files, before the package statement. (See 
+`examples/f/g`.) This renaming of 
 targets is primarily useful for projects that are intended to be installed 
 with goinstall, which requires that the target name match a URL.
 

--- a/README
+++ b/README
@@ -36,7 +36,7 @@ files or .c files will be identified as a target. Each target's name is then
 determined by first looking at its relative path, but can be overridden by 
 either a target.gb file containing a new name, or a //target:<name> comment 
 in one of the source files, before the package statement. (See 
-`examples/f/g`.) This renaming of 
+`./examples/*`.) This renaming of 
 targets is primarily useful for projects that are intended to be installed 
 with goinstall, which requires that the target name match a URL.
 

--- a/example/d/d.go
+++ b/example/d/d.go
@@ -3,13 +3,13 @@ package main
 import (
        "different/a"
        "different/a/b"
-	   "e"
+       "e"
        "g"
 )
 
 func main() {
      a.AFoo()
-	 b.BFoo()
+     b.BFoo()
      g.GFoo()
 	 println(e.CSin(2.4))
 	 println(e.Atoi("5"))

--- a/example/d/d.go
+++ b/example/d/d.go
@@ -4,11 +4,13 @@ import (
        "different/a"
        "different/a/b"
 	   "e"
+       "g"
 )
 
 func main() {
      a.AFoo()
 	 b.BFoo()
+     g.GFoo()
 	 println(e.CSin(2.4))
 	 println(e.Atoi("5"))
 }

--- a/example/f/g/g.go
+++ b/example/f/g/g.go
@@ -1,0 +1,13 @@
+//target:g
+package g
+/* This is a package in a sub-dir where the sub-dir is not a namespace.
+   gb thinks this target is called 'f/g', but we call it 'g'.
+   The comment just before the 'package g' correcs this.
+   We could instead have a file called f/g/target.gb which contains:
+g
+   In other words, just the full name of the target, all by itself.
+*/
+
+func GFoo() {
+	println("GFoo")
+}

--- a/example/f/g/g.go
+++ b/example/f/g/g.go
@@ -2,7 +2,7 @@
 package g
 /* This is a package in a sub-dir where the sub-dir is not a namespace.
    gb thinks this target is called 'f/g', but we call it 'g'.
-   The comment just before the 'package g' correcs this.
+   The comment just before the 'package g' corrects this.
    We could instead have a file called f/g/target.gb which contains:
 g
    In other words, just the full name of the target, all by itself.


### PR DESCRIPTION
Just to clarify how **target.gb** and `//target:name` work.
